### PR TITLE
Add AUR installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ backend = "x11" # or "wayland", "wl". This is case insensitive.
 ```
 
 # Installation
+## AUR
+If you use Arch, you can install lucem directly from the [AUR](https://aur.archlinux.org/packages/lucem-git) using
+```command
+# yay -S lucem-git
+```
+
 ## Building from source
 You will need the following dependencies to compile Lucem:
 


### PR DESCRIPTION
I've created an AUR package, and I have updated the README accordingly so the users are aware of it when looking to install Lucem. (P.S. your discord isn't accepting friend requests, but i'd love to get in touch, mine is JarzaClay)