### PR TITLE
Update README.md to fix a command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ $ lucem clear-cache
 
 ## Installing Desktop File
 ```command
-$ lucem install-desktop-file
+$ lucem install-desktop-files
 ```
 
 ## Installing Systemd Service (run as user, not root!)


### PR DESCRIPTION
Fixed a typo within the command name in the README.md file. The command should be `lucem install-desktop-files` instead of `lucem install-desktop-file`.