### PR TITLE
ci(generate-nix-lock): fix nnl not generating lock.json

### DIFF
--- a/.github/workflows/generate-nix-lock.yml
+++ b/.github/workflows/generate-nix-lock.yml
@@ -14,14 +14,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Nim
-        uses: iffy/install-nim@v5
-      - name: Install nnl
-        run: |
-          nimble install https://github.com/daylinmorgan/nnl
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Generate lock.json
         run: |
-          nnl . -o nix/lock.json
+          nix run github:daylinmorgan/nnl -- . -o nix/lock.json
       - name: Push commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
Sorry for the inconvenience, but I noticed the workflow failed because nnl can't find `nix-prefetch-git` command.
This PR should solve that issue.